### PR TITLE
KenLM autoconversion/fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,49 +62,15 @@ In a first step on should create a ngram. *E.g.* for `polish` the command would 
 ./create_ngram.py --language polish --path_to_ngram polish.arpa
 ```
 
-After the language model is created, one should open the file. one should add a `</s>`
-The file should have a structure which looks more or less as follows:
+After the language model is created, some lines should be converted so it's compatible with 'pyctcdecode'.
+
+Execute the script to run the conversion:
 
 ```
-\data\        
-ngram 1=86586
-ngram 2=546387
-ngram 3=796581           
-ngram 4=843999             
-ngram 5=850874              
-                                                  
-\1-grams:
--5.7532206      <unk>   0
-0       <s>     -0.06677356                                                                            
--3.4645514      drugi   -0.2088903
-...
+./fix_lm.py --path_to_ngram polish.arpa --path_to_fixed polish_fixed.arpa
 ```
 
-Now it is very important also add a `</s>` token to the n-gram
-so that it can be correctly loaded. You can simple copy the line:
-
-`0       <s>     -0.06677356`
-
-and change `<s>` to `</s>`. When doing this you should also inclease `ngram` by 1.
-The new ngram should look as follows:
-
-```
-\data\
-ngram 1=86587
-ngram 2=546387
-ngram 3=796581
-ngram 4=843999
-ngram 5=850874
-
-\1-grams:
--5.7532206      <unk>   0
-0       <s>     -0.06677356
-0       </s>     -0.06677356
--3.4645514      drugi   -0.2088903
-...
-```
-
-Now the ngram can be correctly used with `pyctcdecode`
+Now the generated 'polish_fixed.arpa' ngram can be correctly used with `pyctcdecode`
 
 
 ### Run eval

--- a/fix_lm.py
+++ b/fix_lm.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import argparse
+
+def main(args):
+    '''
+    Function searches for lines that needs to be changed to be supported by
+    PyCTCDecode lib, changes them and writes new KenLM arpa.
+    '''
+    original = open(args.path_to_ngram, 'r').readlines()
+    fixed = open(args.path_to_fixed, 'w')
+
+    for line in original: 
+        if 'ngram 1=' in line:
+            base_ngram_1_line = line 
+            text, value = line.split('=')
+            value = str(float(value.replace('\n', ''))+1)
+            fixed_ngram_1_line = f"{text}={value}\n"
+            fixed.write(fixed_ngram_1_line)
+        elif '\t<s>\t' in line: 
+            base_token_line = line 
+            fixed_token_line = line.replace('\t<s>\t', '\t</s>\t')
+            fixed.write(base_token_line)
+            fixed.write(fixed_token_line)
+        else:
+            fixed.write(line)
+    fixed.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Required parameters
+    parser.add_argument(
+        "--path_to_ngram", type=str, required=True, help="Path to original KenLM ngram"
+    )
+    parser.add_argument(
+        "--path_to_fixed", type=str, required=True, help="Path to write fixed KenLM ngram"
+    )
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
Avoids the ```FormatLoadException``` error by doing automated token & ngram_1 line conversion.

- Input: ```KenLM``` generated arpa lm.
- Output ```pyctcdecode``` supported arpa lm.